### PR TITLE
Replaced share method with singleton method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor/
 composer.lock
+.idea/

--- a/src/JavascriptServiceProvider.php
+++ b/src/JavascriptServiceProvider.php
@@ -20,7 +20,7 @@ class JavascriptServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app['coreplex.bridge.javascript'] = $this->app->share(function ($app) {
+        $this->app->singleton('coreplex.bridge.javascript', function() {
             return new Javascript;
         });
 


### PR DESCRIPTION
`share` is a legacy method which has not been documented for many Laravel versions. The Laravel documentation advises to replace this with the `singleton` method. This also adds support for Laravel 5.4.